### PR TITLE
Remove turbopack and external fonts to fix Next.js build

### DIFF
--- a/Personal-Websites/portfolio-website-2025/README.md
+++ b/Personal-Websites/portfolio-website-2025/README.md
@@ -18,7 +18,6 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More
 

--- a/Personal-Websites/portfolio-website-2025/app/layout.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,11 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
+      <body className="antialiased">{children}</body>
     </html>
   );
 }

--- a/Personal-Websites/portfolio-website-2025/app/projects/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/projects/page.tsx
@@ -1,0 +1,8 @@
+export default function ProjectsPage() {
+  return (
+    <main>
+      <h1>Projects</h1>
+    </main>
+  );
+}
+

--- a/Personal-Websites/portfolio-website-2025/package.json
+++ b/Personal-Websites/portfolio-website-2025/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "dev": "next dev",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint"
   },


### PR DESCRIPTION
## Summary
- drop `--turbopack` to use stable Next.js build
- remove Google font dependency and rely on default system fonts
- add placeholder Projects page to satisfy Next.js routing

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ade6edb9788324852d1c11a979fdcd