### PR TITLE
Allow Vercel Live frames and data URI fonts

### DIFF
--- a/Personal-Websites/portfolio-website-2025/next.config.ts
+++ b/Personal-Websites/portfolio-website-2025/next.config.ts
@@ -6,7 +6,8 @@ const ContentSecurityPolicy = `
   default-src 'self';
   script-src 'self' 'unsafe-inline' https://vercel.live;
   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
-  font-src 'self' https://fonts.gstatic.com;
+  font-src 'self' https://fonts.gstatic.com data:;
+  frame-src 'self' https://vercel.live;
 `;
 
 const nextConfig: NextConfig = {


### PR DESCRIPTION
## Summary
- permit `data:` font sources in CSP
- allow framing content from `vercel.live`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adfb1ab9648324bad43e5fc1deed66