### PR TITLE
feat: add responsive portfolio pages

### DIFF
--- a/Personal-Websites/portfolio-website-2025/app/about/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/about/page.tsx
@@ -1,0 +1,112 @@
+import Image from "next/image";
+
+const services = [
+  {
+    title: "Web Development",
+    img: "https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=600&q=60",
+    desc: "Full‑stack applications and APIs.",
+  },
+  {
+    title: "UI/UX Design",
+    img: "https://images.unsplash.com/photo-1559027615-ce3d4a3b86aa?auto=format&fit=crop&w=600&q=60",
+    desc: "Human‑centered product design.",
+  },
+  {
+    title: "Consulting",
+    img: "https://images.unsplash.com/photo-1522071820081-009f0129c71c?auto=format&fit=crop&w=600&q=60",
+    desc: "Helping teams ship faster.",
+  },
+];
+
+const process = [
+  { step: "Discover", text: "Research, gather requirements and define scope." },
+  { step: "Build", text: "Iterate using agile methodologies and rapid prototypes." },
+  { step: "Launch", text: "Deploy, monitor and continuously improve." },
+];
+
+const testimonials = [
+  {
+    name: "Challenge UCSC",
+    quote:
+      "Artem's thoughtful design helped our program reach more students than ever before.",
+  },
+  {
+    name: "Karina Mois",
+    quote: "Working with Artem was seamless – the final product was stunning and fast.",
+  },
+  {
+    name: "Max Harper",
+    quote: "Our organization's new site boosted engagement thanks to Artem's expertise.",
+  },
+];
+
+export default function AboutPage() {
+  return (
+    <div className="mx-auto max-w-5xl space-y-16 p-4 sm:p-8">
+      <section className="flex flex-col items-center gap-8 md:flex-row">
+        <Image
+          src="https://images.unsplash.com/photo-1502685104226-ee32379fefbe?auto=format&fit=crop&w=400&q=60"
+          alt="Portrait of Artem"
+          width={300}
+          height={300}
+          className="rounded-full object-cover"
+        />
+        <div className="text-center md:text-left">
+          <h1 className="text-4xl font-bold">Hi, I&apos;m Artem</h1>
+          <p className="mt-4 text-lg text-amber-800 dark:text-neutral-300">
+            I&apos;m a developer who loves crafting polished user experiences and
+            solving real‑world problems with code.
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-6 text-2xl font-semibold">Services</h2>
+        <div className="grid gap-6 md:grid-cols-3">
+          {services.map((s) => (
+            <div key={s.title} className="text-center">
+              <Image
+                src={s.img}
+                alt=""
+                width={400}
+                height={250}
+                className="mx-auto h-40 w-full rounded object-cover"
+              />
+              <h3 className="mt-4 font-medium">{s.title}</h3>
+              <p className="mt-2 text-sm text-amber-800 dark:text-neutral-400">
+                {s.desc}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-6 text-2xl font-semibold">My Design Process</h2>
+        <div className="grid gap-6 md:grid-cols-3">
+          {process.map((p) => (
+            <div key={p.step} className="rounded-lg border p-4">
+              <h3 className="font-medium">{p.step}</h3>
+              <p className="mt-2 text-sm text-amber-800 dark:text-neutral-400">
+                {p.text}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-6 text-2xl font-semibold">Testimonials</h2>
+        <div className="grid gap-6 md:grid-cols-3">
+          {testimonials.map((t) => (
+            <blockquote key={t.name} className="rounded-lg bg-neutral-100 p-4 text-sm italic dark:bg-neutral-800">
+              “{t.quote}”
+              <footer className="mt-3 text-right not-italic font-medium">– {t.name}</footer>
+            </blockquote>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/Personal-Websites/portfolio-website-2025/app/contact/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/contact/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+
+const socials = [
+  { href: "mailto:hello@example.com", label: "Email", icon: "📧" },
+  { href: "https://twitter.com/", label: "Twitter", icon: "🐦" },
+  { href: "https://linkedin.com/", label: "LinkedIn", icon: "💼" },
+  { href: "https://instagram.com/", label: "Instagram", icon: "📷" },
+  { href: "https://github.com/", label: "GitHub", icon: "💻" },
+];
+
+export default function ContactPage() {
+  const [sent, setSent] = useState(false);
+
+  return (
+    <section className="mx-auto max-w-5xl grid gap-8 p-4 sm:p-8 md:grid-cols-2">
+      <form
+        className="space-y-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          setSent(true);
+        }}
+      >
+        <input
+          type="text"
+          name="name"
+          required
+          placeholder="Your name"
+          className="w-full rounded border p-2"
+        />
+        <input
+          type="email"
+          name="email"
+          required
+          placeholder="Your email"
+          className="w-full rounded border p-2"
+        />
+        <textarea
+          name="message"
+          rows={5}
+          required
+          placeholder="How can I help?"
+          className="w-full rounded border p-2"
+        />
+        <button
+          type="submit"
+          className="rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700"
+        >
+          Send
+        </button>
+        {sent && (
+          <p className="text-sm text-green-600">Thanks! I&apos;ll be in touch soon.</p>
+        )}
+      </form>
+
+      <div>
+        <h1 className="text-3xl font-bold">Work with me</h1>
+        <p className="mt-4 text-amber-800 dark:text-neutral-300">
+          I&apos;m a graduate excited to take on full‑stack development challenges
+          and always eager to learn new skills.
+        </p>
+        <ul className="mt-6 space-y-2">
+          {socials.map((s) => (
+            <li key={s.label}>
+              <a
+                href={s.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 hover:underline"
+              >
+                <span>{s.icon}</span> {s.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+

--- a/Personal-Websites/portfolio-website-2025/app/globals.css
+++ b/Personal-Websites/portfolio-website-2025/app/globals.css
@@ -5,6 +5,11 @@
   --foreground: #171717;
 }
 
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -12,11 +17,8 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+html {
+  scroll-behavior: smooth;
 }
 
 body {

--- a/Personal-Websites/portfolio-website-2025/app/layout.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Header from "@/components/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,11 +24,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased transition-colors duration-300`}
       >
-        {children}
+        <Header />
+        <main className="pt-16">{children}</main>
       </body>
     </html>
   );

--- a/Personal-Websites/portfolio-website-2025/app/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/page.tsx
@@ -1,105 +1,20 @@
-import Image from "next/image";
-
-
+import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <section className="flex min-h-screen flex-col items-center justify-center gap-6 text-center">
+      <h1 className="text-5xl font-bold">Artem</h1>
+      <p className="max-w-xl text-lg text-amber-800 dark:text-neutral-300">
+        Full‑stack developer crafting fast, responsive experiences across the
+        web.
+      </p>
+      <Link
+        href="/projects"
+        className="rounded-full bg-blue-600 px-6 py-3 text-sm font-medium text-white transition hover:bg-blue-700"
+      >
+        See my work
+      </Link>
+    </section>
   );
 }
+

--- a/Personal-Websites/portfolio-website-2025/app/projects/[slug]/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/projects/[slug]/page.tsx
@@ -1,0 +1,40 @@
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { work } from "@/data/work";
+
+export default function ProjectDetail({ params }: { params: { slug: string } }) {
+  const project = work.find((p) => p.slug === params.slug);
+  if (!project) return notFound();
+
+  return (
+    <section className="mx-auto max-w-5xl p-4 sm:p-8">
+      <div className="grid gap-8 md:grid-cols-3">
+        <div className="md:col-span-2">
+          <h1 className="text-4xl font-bold">{project.title}</h1>
+          <p className="mt-4 text-lg text-amber-800 dark:text-neutral-300">
+            {project.description}
+          </p>
+        </div>
+        <div>
+          <h2 className="text-xl font-semibold">
+            {project.type === "internship" ? "Roles" : "Goals"}
+          </h2>
+          <ul className="mt-3 list-disc pl-4 text-amber-800 dark:text-neutral-300">
+            {project.details.map((d) => (
+              <li key={d}>{d}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <Image
+        src={project.image}
+        alt=""
+        width={800}
+        height={400}
+        className="mt-8 rounded-lg object-cover"
+      />
+    </section>
+  );
+}
+

--- a/Personal-Websites/portfolio-website-2025/app/projects/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/projects/page.tsx
@@ -1,12 +1,38 @@
-import ProjectsGrid from "@/components/ProjectsGrid";
-
-export const metadata = { title: "Projects — Your Name" };
+import Image from "next/image";
+import Link from "next/link";
+import { work } from "@/data/work";
 
 export default function ProjectsPage() {
   return (
-    <div className="py-12 space-y-6">
-      <h1 className="text-2xl font-semibold">Projects</h1>
-      <ProjectsGrid />
-    </div>
+    <section className="mx-auto max-w-5xl space-y-8 p-4 sm:p-8">
+      <div className="space-y-4">
+        <h1 className="text-4xl font-bold">My Work</h1>
+        <p className="text-lg text-amber-800 dark:text-neutral-300">
+          A selection of past projects and internships.
+        </p>
+      </div>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {work.map((p) => (
+          <Link
+            key={p.slug}
+            href={`/projects/${p.slug}`}
+            className="group relative block overflow-hidden rounded-lg shadow transition hover:shadow-lg"
+          >
+            <Image
+              src={p.image}
+              alt={p.title}
+              width={500}
+              height={300}
+              className="h-48 w-full object-cover transition-transform duration-300 group-hover:scale-105"
+            />
+            <div className="absolute inset-0 flex flex-col justify-end bg-black/40 p-4 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+              <h3 className="text-lg font-semibold text-white">{p.title}</h3>
+              <p className="text-sm text-gray-200">{p.scope}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
   );
 }
+

--- a/Personal-Websites/portfolio-website-2025/app/timeline/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/timeline/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { work } from "@/data/work";
+
+export default function TimelinePage() {
+  const items = [...work].sort((a, b) => Number(b.year) - Number(a.year));
+
+  return (
+    <section className="mx-auto max-w-5xl space-y-8 p-4 sm:p-8">
+      <h1 className="text-4xl font-bold">Timeline</h1>
+      <ol className="border-l-2 pl-6 lg:flex lg:border-l-0 lg:border-t-2 lg:pl-0 lg:pt-6">
+        {items.map((item) => (
+          <li
+            key={item.slug}
+            className="relative mb-8 last:mb-0 lg:mb-0 lg:flex-1"
+          >
+            <span className="absolute -left-3 top-1 h-3 w-3 rounded-full bg-blue-600 lg:left-1/2 lg:top-0 lg:-translate-x-1/2 lg:-translate-y-1/2"></span>
+            <time className="text-sm text-amber-700 lg:block lg:text-center">
+              {item.year}
+            </time>
+            <div className="lg:mt-2 lg:text-center">
+              <Link
+                href={`/projects/${item.slug}`}
+                className="font-medium hover:underline"
+              >
+                {item.title}
+              </Link>
+              <p className="text-sm text-amber-800 dark:text-neutral-400">
+                {item.scope}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+

--- a/Personal-Websites/portfolio-website-2025/components/Header.tsx
+++ b/Personal-Websites/portfolio-website-2025/components/Header.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import ThemeToggle from "./ThemeToggle";
+
+/**
+ * Sticky navigation bar with simple mobile menu.
+ */
+export default function Header() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className="fixed inset-x-0 top-0 z-50 bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/40 dark:bg-neutral-900/70 dark:supports-[backdrop-filter]:bg-neutral-900/40">
+      <nav className="mx-auto flex max-w-5xl items-center justify-between p-4">
+        <Link
+          href="/"
+          className="bg-gradient-to-r from-blue-500 to-purple-500 bg-clip-text font-bold text-transparent transition-opacity hover:opacity-80"
+        >
+          Artem
+        </Link>
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+          <button
+            className="rounded bg-white p-2 text-black transition-colors hover:bg-amber-100 sm:hidden dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+            onClick={() => setOpen((v) => !v)}
+            aria-label="Toggle menu"
+          >
+            ☰
+          </button>
+          <ul
+            className={`${open ? "block" : "hidden"} absolute left-0 right-0 top-full mt-2 flex flex-col gap-2 bg-white p-4 text-sm text-black shadow transition-colors dark:bg-neutral-900 dark:text-neutral-100 sm:static sm:mt-0 sm:flex sm:flex-row sm:gap-6 sm:bg-transparent sm:p-0 sm:text-inherit sm:shadow-none`}
+            onClick={() => setOpen(false)}
+          >
+            <li>
+              <Link
+                href="/about"
+                className="relative block rounded bg-white px-3 py-2 text-black transition-colors hover:bg-amber-100 hover:text-amber-700 after:absolute after:left-0 after:-bottom-1 after:h-0.5 after:w-0 after:bg-gradient-to-r from-blue-500 to-purple-500 after:transition-all after:duration-300 hover:after:w-full dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800 dark:hover:text-amber-300 sm:bg-transparent sm:dark:bg-transparent"
+              >
+                About Me
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/projects"
+                className="relative block rounded bg-white px-3 py-2 text-black transition-colors hover:bg-amber-100 hover:text-amber-700 after:absolute after:left-0 after:-bottom-1 after:h-0.5 after:w-0 after:bg-gradient-to-r from-blue-500 to-purple-500 after:transition-all after:duration-300 hover:after:w-full dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800 dark:hover:text-amber-300 sm:bg-transparent sm:dark:bg-transparent"
+              >
+                Projects
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/timeline"
+                className="relative block rounded bg-white px-3 py-2 text-black transition-colors hover:bg-amber-100 hover:text-amber-700 after:absolute after:left-0 after:-bottom-1 after:h-0.5 after:w-0 after:bg-gradient-to-r from-blue-500 to-purple-500 after:transition-all after:duration-300 hover:after:w-full dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800 dark:hover:text-amber-300 sm:bg-transparent sm:dark:bg-transparent"
+              >
+                Timeline
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/contact"
+                className="relative block rounded bg-white px-3 py-2 text-black transition-colors hover:bg-amber-100 hover:text-amber-700 after:absolute after:left-0 after:-bottom-1 after:h-0.5 after:w-0 after:bg-gradient-to-r from-blue-500 to-purple-500 after:transition-all after:duration-300 hover:after:w-full dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800 dark:hover:text-amber-300 sm:bg-transparent sm:dark:bg-transparent"
+              >
+                Contact
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </nav>
+    </header>
+  );
+}
+

--- a/Personal-Websites/portfolio-website-2025/components/ProjectCard.tsx
+++ b/Personal-Websites/portfolio-website-2025/components/ProjectCard.tsx
@@ -7,14 +7,29 @@ export type { Project };
 
 export default function ProjectCard({ p }: { p: Project }) {
   return (
-    <article className="rounded-2xl border p-4">
+    <article
+      className="group rounded-2xl border p-4 transition hover:-translate-y-1 hover:shadow-lg dark:border-neutral-700"
+    >
       <div className="flex items-baseline justify-between">
-        <h3 className="font-medium">{p.title}</h3>
-        <span className="text-xs text-neutral-500">{p.year}</span>
+        <h3 className="font-medium transition-colors group-hover:text-blue-600">
+          {p.title}
+        </h3>
+        <span className="text-xs text-amber-700 group-hover:text-amber-900 dark:group-hover:text-amber-300">
+          {p.year}
+        </span>
       </div>
-      <p className="mt-2 text-sm text-neutral-700">{p.blurb}</p>
-      <div className="mt-3 flex flex-wrap gap-2 text-xs text-neutral-600">
-        {p.tags.map((t) => <span key={t} className="rounded-full border px-2 py-0.5">{t}</span>)}
+      <p className="mt-2 text-sm text-amber-800 dark:text-neutral-300">
+        {p.blurb}
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2 text-xs text-amber-800 dark:text-neutral-400">
+        {p.tags.map((t) => (
+          <span
+            key={t}
+            className="rounded-full border px-2 py-0.5 transition-colors group-hover:border-blue-600 group-hover:text-blue-600 dark:border-neutral-600"
+          >
+            {t}
+          </span>
+        ))}
       </div>
     </article>
   );

--- a/Personal-Websites/portfolio-website-2025/components/ThemeToggle.tsx
+++ b/Personal-Websites/portfolio-website-2025/components/ThemeToggle.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle() {
+  const [mounted, setMounted] = useState(false);
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const stored = localStorage.getItem("theme");
+    const initial = stored ? stored === "dark" : mql.matches;
+    setDark(initial);
+    document.documentElement.classList.toggle("dark", initial);
+  }, []);
+
+  if (!mounted) return null;
+
+  const toggle = () => {
+    const next = !dark;
+    setDark(next);
+    document.documentElement.classList.toggle("dark", next);
+    localStorage.setItem("theme", next ? "dark" : "light");
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label="Toggle dark mode"
+      className="ml-4 rounded p-2 transition-colors hover:bg-black/5 dark:hover:bg-white/10"
+    >
+      {dark ? "🌙" : "☀️"}
+    </button>
+  );
+}

--- a/Personal-Websites/portfolio-website-2025/data/work.ts
+++ b/Personal-Websites/portfolio-website-2025/data/work.ts
@@ -1,0 +1,86 @@
+export type WorkItem = {
+  slug: string;
+  title: string;
+  scope: string;
+  image: string;
+  description: string;
+  year: string;
+  type: "project" | "internship";
+  details: string[]; // goals or roles
+};
+
+export const work: WorkItem[] = [
+  {
+    slug: "responsive-app",
+    title: "Responsive Web App",
+    scope: "Full‑stack project",
+    image:
+      "https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=800&q=60",
+    description:
+      "A performant web application demonstrating responsive layouts and fast loading techniques.",
+    year: "2024",
+    type: "project",
+    details: ["Goal: Optimize Core Web Vitals", "Goal: Mobile‑first UX", "Goal: Deployed with CI/CD"],
+  },
+  {
+    slug: "design-system",
+    title: "Design System Internship",
+    scope: "UI component library",
+    image:
+      "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=800&q=60",
+    description:
+      "Collaborated on a scalable design system used across multiple products.",
+    year: "2023",
+    type: "internship",
+    details: ["Role: Built accessible components", "Role: Wrote Storybook docs", "Role: Led design reviews"],
+  },
+  {
+    slug: "data-visualizer",
+    title: "Data Visualizer",
+    scope: "Interactive charts",
+    image:
+      "https://images.unsplash.com/photo-1531497865144-0464ef8fb40e?auto=format&fit=crop&w=800&q=60",
+    description:
+      "Visualization tool turning raw metrics into animated dashboards.",
+    year: "2022",
+    type: "project",
+    details: ["Goal: Real‑time updates", "Goal: Export to CSV", "Goal: Custom theming"],
+  },
+  {
+    slug: "ux-research",
+    title: "UX Research Assistant",
+    scope: "Research internship",
+    image:
+      "https://images.unsplash.com/photo-1537432376769-00a7d6b1e619?auto=format&fit=crop&w=800&q=60",
+    description:
+      "Supported user studies and prototyping for a mobile application.",
+    year: "2021",
+    type: "internship",
+    details: ["Role: Conducted surveys", "Role: Built hi‑fi prototypes", "Role: Presented findings"],
+  },
+  {
+    slug: "game-engine",
+    title: "Mini Game Engine",
+    scope: "Graphics project",
+    image:
+      "https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=800&q=60",
+    description:
+      "Lightweight engine showcasing physics and sprite animation.",
+    year: "2020",
+    type: "project",
+    details: ["Goal: Entity system", "Goal: Physics integration", "Goal: Level editor"],
+  },
+  {
+    slug: "automation-coop",
+    title: "Automation Co‑op",
+    scope: "Tooling internship",
+    image:
+      "https://images.unsplash.com/photo-1487058792275-0ad4aaf24ca7?auto=format&fit=crop&w=800&q=60",
+    description:
+      "Built internal tools to streamline deployment pipelines.",
+    year: "2019",
+    type: "internship",
+    details: ["Role: Created CLI utilities", "Role: Improved build times", "Role: Monitored metrics"],
+  },
+];
+

--- a/Personal-Websites/portfolio-website-2025/next.config.ts
+++ b/Personal-Websites/portfolio-website-2025/next.config.ts
@@ -6,10 +6,23 @@ const ContentSecurityPolicy = `
   default-src 'self';
   script-src 'self' 'unsafe-inline' https://vercel.live;
   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+  img-src 'self' https://images.unsplash.com https://placehold.co data:;
   font-src 'self' https://fonts.gstatic.com data:;
 `;
 
 const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+      },
+      {
+        protocol: "https",
+        hostname: "placehold.co",
+      },
+    ],
+  },
   async headers() {
     return [
       {

--- a/Personal-Websites/portfolio-website-2025/tailwind.config.ts
+++ b/Personal-Websites/portfolio-website-2025/tailwind.config.ts
@@ -1,0 +1,6 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  darkMode: "class",
+} satisfies Config;


### PR DESCRIPTION
## Summary
- align nav button backgrounds with header and show black text in light mode
- lighten testimonial cards in light mode
- switch timeline to horizontal layout on large screens

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` and `Geist Mono` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68af9da80a508324913ced6027b47d30