### PR TITLE
fix image loading and light mode text color

### DIFF
--- a/Personal-Websites/portfolio-website-2025/app/about/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/about/page.tsx
@@ -49,11 +49,11 @@ export default function AboutPage() {
           alt="Portrait of Artem"
           width={300}
           height={300}
-          className="rounded-full object-cover"
+          className="h-[300px] w-[300px] rounded-full object-cover"
         />
         <div className="text-center md:text-left">
           <h1 className="text-4xl font-bold">Hi, I&apos;m Artem</h1>
-          <p className="mt-4 text-lg text-amber-800 dark:text-neutral-300">
+          <p className="mt-4 text-lg text-black dark:text-neutral-300">
             I&apos;m a developer who loves crafting polished user experiences and
             solving real‑world problems with code.
           </p>
@@ -70,10 +70,10 @@ export default function AboutPage() {
                 alt=""
                 width={400}
                 height={250}
-                className="mx-auto h-40 w-full rounded object-cover"
+                className="mx-auto w-full h-auto rounded object-cover"
               />
               <h3 className="mt-4 font-medium">{s.title}</h3>
-              <p className="mt-2 text-sm text-amber-800 dark:text-neutral-400">
+              <p className="mt-2 text-sm text-black dark:text-neutral-400">
                 {s.desc}
               </p>
             </div>
@@ -87,7 +87,7 @@ export default function AboutPage() {
           {process.map((p) => (
             <div key={p.step} className="rounded-lg border p-4">
               <h3 className="font-medium">{p.step}</h3>
-              <p className="mt-2 text-sm text-amber-800 dark:text-neutral-400">
+              <p className="mt-2 text-sm text-black dark:text-neutral-400">
                 {p.text}
               </p>
             </div>
@@ -99,7 +99,7 @@ export default function AboutPage() {
         <h2 className="mb-6 text-2xl font-semibold">Testimonials</h2>
         <div className="grid gap-6 md:grid-cols-3">
           {testimonials.map((t) => (
-            <blockquote key={t.name} className="rounded-lg bg-neutral-100 p-4 text-sm italic dark:bg-neutral-800">
+            <blockquote key={t.name} className="rounded-lg bg-neutral-100 p-4 text-sm italic text-black dark:bg-neutral-800 dark:text-neutral-300">
               “{t.quote}”
               <footer className="mt-3 text-right not-italic font-medium">– {t.name}</footer>
             </blockquote>

--- a/Personal-Websites/portfolio-website-2025/app/contact/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/contact/page.tsx
@@ -56,7 +56,7 @@ export default function ContactPage() {
 
       <div>
         <h1 className="text-3xl font-bold">Work with me</h1>
-        <p className="mt-4 text-amber-800 dark:text-neutral-300">
+        <p className="mt-4 text-black dark:text-neutral-300">
           I&apos;m a graduate excited to take on full‑stack development challenges
           and always eager to learn new skills.
         </p>

--- a/Personal-Websites/portfolio-website-2025/app/globals.css
+++ b/Personal-Websites/portfolio-website-2025/app/globals.css
@@ -2,17 +2,14 @@
 
 :root {
   --background: #ffffff;
-  --foreground: #171717;
 }
 
 .dark {
   --background: #0a0a0a;
-  --foreground: #ededed;
 }
 
 @theme inline {
   --color-background: var(--background);
-  --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
@@ -23,6 +20,5 @@ html {
 
 body {
   background: var(--background);
-  color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/Personal-Websites/portfolio-website-2025/app/layout.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/layout.tsx
@@ -24,9 +24,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased transition-colors duration-300`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased text-black dark:text-neutral-100 transition-colors duration-300`}
       >
         <Header />
         <main className="pt-16">{children}</main>

--- a/Personal-Websites/portfolio-website-2025/app/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/page.tsx
@@ -4,7 +4,7 @@ export default function Home() {
   return (
     <section className="flex min-h-screen flex-col items-center justify-center gap-6 text-center">
       <h1 className="text-5xl font-bold">Artem</h1>
-      <p className="max-w-xl text-lg text-amber-800 dark:text-neutral-300">
+      <p className="max-w-xl text-lg text-black dark:text-neutral-300">
         Full‑stack developer crafting fast, responsive experiences across the
         web.
       </p>

--- a/Personal-Websites/portfolio-website-2025/app/projects/[slug]/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/projects/[slug]/page.tsx
@@ -11,7 +11,7 @@ export default function ProjectDetail({ params }: { params: { slug: string } }) 
       <div className="grid gap-8 md:grid-cols-3">
         <div className="md:col-span-2">
           <h1 className="text-4xl font-bold">{project.title}</h1>
-          <p className="mt-4 text-lg text-amber-800 dark:text-neutral-300">
+          <p className="mt-4 text-lg text-black dark:text-neutral-300">
             {project.description}
           </p>
         </div>
@@ -19,7 +19,7 @@ export default function ProjectDetail({ params }: { params: { slug: string } }) 
           <h2 className="text-xl font-semibold">
             {project.type === "internship" ? "Roles" : "Goals"}
           </h2>
-          <ul className="mt-3 list-disc pl-4 text-amber-800 dark:text-neutral-300">
+          <ul className="mt-3 list-disc pl-4 text-black dark:text-neutral-300">
             {project.details.map((d) => (
               <li key={d}>{d}</li>
             ))}
@@ -32,7 +32,7 @@ export default function ProjectDetail({ params }: { params: { slug: string } }) 
         alt=""
         width={800}
         height={400}
-        className="mt-8 rounded-lg object-cover"
+        className="mt-8 w-full h-auto rounded-lg object-cover"
       />
     </section>
   );

--- a/Personal-Websites/portfolio-website-2025/app/projects/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/projects/page.tsx
@@ -7,7 +7,7 @@ export default function ProjectsPage() {
     <section className="mx-auto max-w-5xl space-y-8 p-4 sm:p-8">
       <div className="space-y-4">
         <h1 className="text-4xl font-bold">My Work</h1>
-        <p className="text-lg text-amber-800 dark:text-neutral-300">
+        <p className="text-lg text-black dark:text-neutral-300">
           A selection of past projects and internships.
         </p>
       </div>
@@ -23,7 +23,7 @@ export default function ProjectsPage() {
               alt={p.title}
               width={500}
               height={300}
-              className="h-48 w-full object-cover transition-transform duration-300 group-hover:scale-105"
+              className="w-full h-auto object-cover transition-transform duration-300 group-hover:scale-105"
             />
             <div className="absolute inset-0 flex flex-col justify-end bg-black/40 p-4 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
               <h3 className="text-lg font-semibold text-white">{p.title}</h3>

--- a/Personal-Websites/portfolio-website-2025/app/timeline/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/timeline/page.tsx
@@ -14,7 +14,7 @@ export default function TimelinePage() {
             className="relative mb-8 last:mb-0 lg:mb-0 lg:flex-1"
           >
             <span className="absolute -left-3 top-1 h-3 w-3 rounded-full bg-blue-600 lg:left-1/2 lg:top-0 lg:-translate-x-1/2 lg:-translate-y-1/2"></span>
-            <time className="text-sm text-amber-700 lg:block lg:text-center">
+            <time className="text-sm text-black dark:text-neutral-400 lg:block lg:text-center">
               {item.year}
             </time>
             <div className="lg:mt-2 lg:text-center">
@@ -24,7 +24,7 @@ export default function TimelinePage() {
               >
                 {item.title}
               </Link>
-              <p className="text-sm text-amber-800 dark:text-neutral-400">
+              <p className="text-sm text-black dark:text-neutral-400">
                 {item.scope}
               </p>
             </div>

--- a/Personal-Websites/portfolio-website-2025/components/ProjectCard.tsx
+++ b/Personal-Websites/portfolio-website-2025/components/ProjectCard.tsx
@@ -14,14 +14,14 @@ export default function ProjectCard({ p }: { p: Project }) {
         <h3 className="font-medium transition-colors group-hover:text-blue-600">
           {p.title}
         </h3>
-        <span className="text-xs text-amber-700 group-hover:text-amber-900 dark:group-hover:text-amber-300">
+        <span className="text-xs text-black group-hover:text-amber-900 dark:group-hover:text-amber-300">
           {p.year}
         </span>
       </div>
-      <p className="mt-2 text-sm text-amber-800 dark:text-neutral-300">
+      <p className="mt-2 text-sm text-black dark:text-neutral-300">
         {p.blurb}
       </p>
-      <div className="mt-3 flex flex-wrap gap-2 text-xs text-amber-800 dark:text-neutral-400">
+      <div className="mt-3 flex flex-wrap gap-2 text-xs text-black dark:text-neutral-400">
         {p.tags.map((t) => (
           <span
             key={t}

--- a/Personal-Websites/portfolio-website-2025/next.config.ts
+++ b/Personal-Websites/portfolio-website-2025/next.config.ts
@@ -16,10 +16,12 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         hostname: "images.unsplash.com",
+        pathname: "/**",
       },
       {
         protocol: "https",
         hostname: "placehold.co",
+        pathname: "/**",
       },
     ],
   },


### PR DESCRIPTION
## Summary
- allow Unsplash and Placehold images by specifying remote pattern paths
- use Tailwind to default text to black in light mode and add html scroll-behavior attribute
- update images and content styles to prevent layout warnings

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0cd51ace48324b2b54416390f9b96