### PR TITLE
refactor: simplify global theme setup

### DIFF
--- a/Personal-Websites/portfolio-website-2025/app/globals.css
+++ b/Personal-Websites/portfolio-website-2025/app/globals.css
@@ -1,24 +1,23 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-}
+@layer base {
+  :root {
+    --background: #ffffff;
+    --color-background: var(--background);
+    --font-sans: var(--font-geist-sans);
+    --font-mono: var(--font-geist-mono);
+  }
 
-.dark {
-  --background: #0a0a0a;
-}
+  .dark {
+    --background: #0a0a0a;
+  }
 
-@theme inline {
-  --color-background: var(--background);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
+  html {
+    scroll-behavior: smooth;
+  }
 
-html {
-  scroll-behavior: smooth;
-}
-
-body {
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  body {
+    background: var(--color-background);
+    font-family: var(--font-sans, Arial, Helvetica, sans-serif);
+  }
 }


### PR DESCRIPTION
## Summary
- replace unsupported `@theme inline` with standard `@layer base` and CSS variables

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b10849626c8324924a55d7dbd4b40d