### PR TITLE
Fix theme initialization and header color for light mode

### DIFF
--- a/Personal-Websites/portfolio-website-2025/app/layout.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/layout.tsx
@@ -25,6 +25,23 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+(function () {
+  try {
+    var stored = localStorage.getItem('theme');
+    var mql = window.matchMedia('(prefers-color-scheme: dark)');
+    var dark = stored ? stored === 'dark' : mql.matches;
+    var c = document.documentElement.classList;
+    if (dark) c.add('dark'); else c.remove('dark');
+  } catch (_) {}
+})();
+            `,
+          }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased text-black dark:text-neutral-100 transition-colors duration-300`}
       >

--- a/Personal-Websites/portfolio-website-2025/components/Header.tsx
+++ b/Personal-Websites/portfolio-website-2025/components/Header.tsx
@@ -29,7 +29,7 @@ export default function Header() {
             ☰
           </button>
           <ul
-            className={`${open ? "block" : "hidden"} absolute left-0 right-0 top-full mt-2 flex flex-col gap-2 bg-white p-4 text-sm text-black shadow transition-colors dark:bg-neutral-900 dark:text-neutral-100 sm:static sm:mt-0 sm:flex sm:flex-row sm:gap-6 sm:bg-transparent sm:p-0 sm:text-inherit sm:shadow-none`}
+            className={`${open ? "block" : "hidden"} absolute left-0 right-0 top-full mt-2 flex flex-col gap-2 bg-white p-4 text-sm text-black shadow transition-colors dark:bg-neutral-900 dark:text-neutral-100 sm:static sm:mt-0 sm:flex sm:flex-row sm:gap-6 sm:bg-transparent sm:p-0 sm:shadow-none sm:dark:bg-transparent`}
             onClick={() => setOpen(false)}
           >
             <li>

--- a/Personal-Websites/portfolio-website-2025/components/ThemeToggle.tsx
+++ b/Personal-Websites/portfolio-website-2025/components/ThemeToggle.tsx
@@ -8,11 +8,7 @@ export default function ThemeToggle() {
 
   useEffect(() => {
     setMounted(true);
-    const mql = window.matchMedia("(prefers-color-scheme: dark)");
-    const stored = localStorage.getItem("theme");
-    const initial = stored ? stored === "dark" : mql.matches;
-    setDark(initial);
-    document.documentElement.classList.toggle("dark", initial);
+    setDark(document.documentElement.classList.contains("dark"));
   }, []);
 
   if (!mounted) return null;


### PR DESCRIPTION
## Summary
- initialize dark mode class before hydration to avoid mismatched styles
- read theme state from existing DOM class and remove inheriting menu colors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b133befc68832492ede46528276007