### PR TITLE
Add centered profile image to landing page

### DIFF
--- a/Personal-Websites/portfolio-website-2025/app/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/page.tsx
@@ -1,8 +1,17 @@
 import Link from "next/link";
+import Image from "next/image";
 
 export default function Home() {
   return (
     <section className="flex min-h-screen flex-col items-center justify-center gap-6 text-center">
+      <Image
+        src="/Artem%20Photos/SlightSmile.jpeg"
+        alt="Portrait of Artem Zagaynov"
+        width={200}
+        height={200}
+        className="rounded-full"
+        priority
+      />
       <h1 className="text-5xl font-bold">Artem Zagaynov</h1>
       <p className="max-w-xl text-lg">
         Full‑stack developer crafting fast, responsive experiences across the


### PR DESCRIPTION
## Summary
- show profile image on landing page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1f1a03b208324aead5ce97fad4769