### PR TITLE
Replace consulting service with avionics

### DIFF
--- a/Personal-Websites/portfolio-website-2025/app/about/page.tsx
+++ b/Personal-Websites/portfolio-website-2025/app/about/page.tsx
@@ -12,7 +12,7 @@ const services = [
     desc: "Human‑centered product design.",
   },
   {
-    title: "Consulting",
+    title: "Avionics",
     img: "https://images.unsplash.com/photo-1522071820081-009f0129c71c?auto=format&fit=crop&w=600&q=60",
     desc: "Helping teams ship faster.",
   },


### PR DESCRIPTION
## Summary
- replace "Consulting" service with "Avionics" on the portfolio About page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c204b6c5c883248c52687a7ca3af22